### PR TITLE
Adds support for multiple presentations on different branches

### DIFF
--- a/lib/git_presenter.rb
+++ b/lib/git_presenter.rb
@@ -4,9 +4,9 @@ require 'readline'
 require 'launchy'
 
 class GitPresenter
-  require 'git_presenter/presentation'
-  require 'git_presenter/controller'
-  require 'git_presenter/slide'
+  require_relative 'git_presenter/presentation'
+  require_relative 'git_presenter/controller'
+  require_relative 'git_presenter/slide'
 
   def initialize(current_dir, interactive=true)
     @controller = Controller.new(current_dir)

--- a/lib/git_presenter/controller.rb
+++ b/lib/git_presenter/controller.rb
@@ -6,7 +6,7 @@ class GitPresenter::Controller
   end
 
   def initialise_presentation
-    yaml = {"slides" => create_slides}.to_yaml
+    yaml = {"slides" => create_slides, "branch" => current_branch}.to_yaml
     File.open(presentation_file_location, "w") do |file|
       file.write(yaml)
     end
@@ -24,7 +24,6 @@ class GitPresenter::Controller
   def update_presentation
     yaml = YAML.parse(File.open(@presentation_dir + "/.presentation", "r")).to_ruby
     slides = create_slides(yaml['slides'].last["slide"]["commit"])
-    last_commit = yaml["slides"].last
     yaml["slides"] = yaml["slides"] + slides
     yaml["slides"].uniq!
     write_file(yaml.to_yaml)
@@ -53,5 +52,9 @@ class GitPresenter::Controller
          "message" => commit.message}
       }
     end
+  end
+
+  def current_branch
+    `git rev-parse --abbrev-ref HEAD`.strip
   end
 end

--- a/lib/git_presenter/presentation.rb
+++ b/lib/git_presenter/presentation.rb
@@ -2,6 +2,7 @@ class GitPresenter::Presentation
   attr_reader :slides, :current_slide
 
   def initialize(presentation)
+    @branch = presentation["branch"]
     @slides = presentation["slides"].map{|slide| GitPresenter::Slide.new(slide["slide"])}
     @current_slide = slides.first
   end
@@ -39,7 +40,7 @@ class GitPresenter::Presentation
   end
 
   def exit
-    `git checkout -q master`
+    `git checkout -q #{@branch}`
     :exit
   end
 

--- a/spec/integration/initialize_presentation_spec.rb
+++ b/spec/integration/initialize_presentation_spec.rb
@@ -20,6 +20,12 @@ describe "initializing a presentation" do
       end
     end
 
+    it 'should have a branch note' do
+      @helper.initialise_presentation do |commits, yaml|
+        yaml["branch"].should_not be_nil
+      end
+    end
+
     it "should contain a line for each commit to the repository" do
       @helper.initialise_presentation do |commits, yaml|
         yaml["slides"].length.should eql commits.length

--- a/spec/lib/git_presenter/presentation_spec.rb
+++ b/spec/lib/git_presenter/presentation_spec.rb
@@ -4,7 +4,8 @@ describe GitPresenter::Presentation do
   let(:presentation){ {"slides" => [
                           {"slide" => {"commit" => "0"}},
                           {"slide" => {"commit" => "1"}},
-                          {"slide" => {"commit" => "2"}}]
+                          {"slide" => {"commit" => "2"}}],
+                       "branch" => "test"
                       }
                     }
   context "when displaying the command line" do
@@ -82,6 +83,17 @@ describe GitPresenter::Presentation do
 
     context "with help" do
       it { given_command("help").should eql :help}
+    end
+
+    context "with exit" do
+      it { given_command("exit").should eql :exit}
+      it 'checks out to the correct branch' do
+        presenter = GitPresenter::Presentation.new(presentation)
+
+        expect(presenter).to receive(:'`').with("git checkout -q #{presentation['branch']}")
+
+        presenter.exit
+      end
     end
   end
 end


### PR DESCRIPTION
- Saves the current branch in `.presentation` at the time of
  initialization
- The exit command checks out to that branch instead of always checking
  out to master
