### PR TITLE
Bsb/modern rubies fix yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ doc
 .bundle
 pkg
 presentation
+a_file.rb
+git_presenter*.gem

--- a/bin/git-presenter
+++ b/bin/git-presenter
@@ -2,7 +2,7 @@
 require "rubygems"
 require_relative "../lib/git_presenter"
 
-YAML::ENGINE.yamler = 'psych'
+YAML::ENGINE.yamler = 'psych' if defined?(Psych::ENGINE)
 
 if ARGV[1] == "-c"
   interactive = false


### PR DESCRIPTION
In certain Rubies, I believe 2.2 and up, the constant `Psych::ENGINE` is not defined and psych is already the default engine for yaml. So I added a conditional on the offending line in `bin/git-presenter`